### PR TITLE
feat: initialize template repos and expand editing

### DIFF
--- a/src/components/templates/TemplateEditor.tsx
+++ b/src/components/templates/TemplateEditor.tsx
@@ -10,12 +10,49 @@ export default function TemplateEditor({ db, persist }: { db: DB; persist: (u:(d
   const [template, setTemplate] = useState<ProjectTemplate>(editing ? db.templates.find(t=>t.id===id)! : {
     id: uid(), name: "", description: "", defaults: {}
   });
-  useEffect(()=>{ if (editing) setTemplate(db.templates.find(t=>t.id===id)!); },[editing,id]);
+  const [outcomes, setOutcomes] = useState("[]");
+  const [tasks, setTasks] = useState("[]");
+  const [risks, setRisks] = useState("[]");
+  const [outOfScope, setOutOfScope] = useState("[]");
+  const [prereqs, setPrereqs] = useState("[]");
+  const [training, setTraining] = useState("[]");
+  const [teamRoles, setTeamRoles] = useState("[]");
+  const [teamModeling, setTeamModeling] = useState("[]");
+  useEffect(()=>{ if (editing) {
+      const t = db.templates.find(t=>t.id===id)!;
+      setTemplate(t);
+      setOutcomes(JSON.stringify(t.defaults.outcomes ?? [], null, 2));
+      setTasks(JSON.stringify(t.defaults.tasks ?? [], null, 2));
+      setRisks(JSON.stringify(t.defaults.risks ?? [], null, 2));
+      setOutOfScope(JSON.stringify(t.defaults.outOfScope ?? [], null, 2));
+      setPrereqs(JSON.stringify(t.defaults.prereqs ?? [], null, 2));
+      setTraining(JSON.stringify(t.defaults.training ?? [], null, 2));
+      setTeamRoles(JSON.stringify(t.defaults.teamRoles ?? [], null, 2));
+      setTeamModeling(JSON.stringify(t.defaults.teamModeling ?? [], null, 2));
+    }
+  },[editing,id,db.templates]);
 
+  function parse<T>(str: string, fallback: T): T {
+    try { return str.trim() ? JSON.parse(str) : fallback; } catch { return fallback; }
+  }
   function save() {
+    const updated: ProjectTemplate = {
+      ...template,
+      defaults: {
+        ...template.defaults,
+        outcomes: parse(outcomes, []),
+        tasks: parse(tasks, []),
+        risks: parse(risks, []),
+        outOfScope: parse(outOfScope, []),
+        prereqs: parse(prereqs, []),
+        training: parse(training, []),
+        teamRoles: parse(teamRoles, []),
+        teamModeling: parse(teamModeling, []),
+      }
+    };
     persist(d => {
-      if (editing) d.templates = d.templates.map(t => t.id===template.id? template : t);
-      else d.templates.push(template);
+      if (editing) d.templates = d.templates.map(t => t.id===updated.id? updated : t);
+      else d.templates.push(updated);
     });
     navigate('/templates');
   }
@@ -25,15 +62,39 @@ export default function TemplateEditor({ db, persist }: { db: DB; persist: (u:(d
       <Title headingLevel="h2">{editing? 'Edit Template' : 'New Template'}</Title>
       <Card isCompact>
         <CardBody>
-          <Form>
-            <FormGroup label="Name" isRequired fieldId="temp-name">
-              <TextInput id="temp-name" value={template.name} onChange={(_,v)=>setTemplate({...template, name:v})} />
-            </FormGroup>
-            <FormGroup label="Description" fieldId="temp-desc">
-              <TextArea id="temp-desc" value={template.description} onChange={(_,v)=>setTemplate({...template, description:v})} />
-            </FormGroup>
-          </Form>
-        </CardBody>
+            <Form>
+              <FormGroup label="Name" isRequired fieldId="temp-name">
+                <TextInput id="temp-name" value={template.name} onChange={(_,v)=>setTemplate({...template, name:v})} />
+              </FormGroup>
+              <FormGroup label="Description" fieldId="temp-desc">
+                <TextArea id="temp-desc" value={template.description} onChange={(_,v)=>setTemplate({...template, description:v})} />
+              </FormGroup>
+              <FormGroup label="Outcomes (JSON)" fieldId="temp-outcomes">
+                <TextArea id="temp-outcomes" value={outcomes} onChange={(_,v)=>setOutcomes(v)} />
+              </FormGroup>
+              <FormGroup label="Tasks (JSON)" fieldId="temp-tasks">
+                <TextArea id="temp-tasks" value={tasks} onChange={(_,v)=>setTasks(v)} />
+              </FormGroup>
+              <FormGroup label="Risks (JSON)" fieldId="temp-risks">
+                <TextArea id="temp-risks" value={risks} onChange={(_,v)=>setRisks(v)} />
+              </FormGroup>
+              <FormGroup label="Out of scope (JSON)" fieldId="temp-oos">
+                <TextArea id="temp-oos" value={outOfScope} onChange={(_,v)=>setOutOfScope(v)} />
+              </FormGroup>
+              <FormGroup label="Prerequisites (JSON)" fieldId="temp-prereqs">
+                <TextArea id="temp-prereqs" value={prereqs} onChange={(_,v)=>setPrereqs(v)} />
+              </FormGroup>
+              <FormGroup label="Training recommendations (JSON)" fieldId="temp-training">
+                <TextArea id="temp-training" value={training} onChange={(_,v)=>setTraining(v)} />
+              </FormGroup>
+              <FormGroup label="Team roles (JSON)" fieldId="temp-teamroles">
+                <TextArea id="temp-teamroles" value={teamRoles} onChange={(_,v)=>setTeamRoles(v)} />
+              </FormGroup>
+              <FormGroup label="Team modeling (JSON)" fieldId="temp-teammodeling">
+                <TextArea id="temp-teammodeling" value={teamModeling} onChange={(_,v)=>setTeamModeling(v)} />
+              </FormGroup>
+            </Form>
+          </CardBody>
         <CardFooter>
           <Button variant="primary" onClick={save}>Save</Button>
           <Button variant="link" onClick={()=>navigate(-1)}>Cancel</Button>

--- a/src/components/templates/TemplatesList.test.tsx
+++ b/src/components/templates/TemplatesList.test.tsx
@@ -8,6 +8,8 @@ import { api } from '../../lib/api';
 jest.mock('../../lib/api', () => ({
   api: {
     getTemplate: jest.fn(),
+    isRepoEmpty: jest.fn(),
+    initTemplate: jest.fn(),
     loadMeta: jest.fn(() => Promise.resolve({ recents: [], prefs: {} })),
     saveMeta: jest.fn(() => Promise.resolve()),
     copyTemplate: jest.fn(),
@@ -15,6 +17,7 @@ jest.mock('../../lib/api', () => ({
 }));
 
 test('loads template from repo', async () => {
+  (api.isRepoEmpty as jest.Mock).mockResolvedValue(false);
   (api.getTemplate as jest.Mock).mockResolvedValue(seedTemplate);
   render(
     <MemoryRouter>
@@ -24,5 +27,22 @@ test('loads template from repo', async () => {
   fireEvent.change(screen.getByPlaceholderText('owner/repo'), { target: { value: 'foo/bar' } });
   fireEvent.click(screen.getAllByText('Load template')[0]);
   expect(await screen.findByText(seedTemplate.name)).toBeTruthy();
+});
+
+test('initializes empty template repo', async () => {
+  (api.isRepoEmpty as jest.Mock).mockResolvedValue(true);
+  (api.initTemplate as jest.Mock).mockResolvedValue(undefined);
+  render(
+    <MemoryRouter>
+      <TemplatesList />
+    </MemoryRouter>
+  );
+  fireEvent.change(screen.getByPlaceholderText('owner/repo'), { target: { value: 'foo/bar' } });
+  fireEvent.click(screen.getAllByText('Load template')[0]);
+  const nameInput = await screen.findByPlaceholderText('Template name');
+  fireEvent.change(nameInput, { target: { value: 'My Tmpl' } });
+  fireEvent.change(screen.getByPlaceholderText('Description'), { target: { value: 'desc' } });
+  fireEvent.click(screen.getByText('Create template'));
+  expect(api.initTemplate).toHaveBeenCalled();
 });
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,4 +1,4 @@
-import { loadOpportunity, loadTemplate, copyTemplateToRepo, RepoRef } from './github';
+import { loadOpportunity, loadTemplate, copyTemplateToRepo, RepoRef, isRepoEmpty, initTemplateRepo } from './github';
 import { loadMeta, saveMeta, UserMeta } from './persistence';
 import { ProjectTemplate, OpportunityInfo } from '../models/types';
 
@@ -6,6 +6,8 @@ export interface API {
   getTemplate(repo: RepoRef): Promise<ProjectTemplate>;
   getOpportunity(repo: RepoRef): Promise<OpportunityInfo>;
   copyTemplate(src: RepoRef, dest: RepoRef, files?: string[]): Promise<void>;
+  isRepoEmpty(repo: RepoRef): Promise<boolean>;
+  initTemplate(repo: RepoRef, template: ProjectTemplate): Promise<void>;
   loadMeta(): Promise<UserMeta>;
   saveMeta(update: Partial<UserMeta>): Promise<void>;
 }
@@ -23,6 +25,8 @@ export const api: API = {
   getTemplate: async (repo) => loadTemplate(await getOctokit(), repo),
   getOpportunity: async (repo) => loadOpportunity(await getOctokit(), repo),
   copyTemplate: async (src, dest, files) => copyTemplateToRepo(await getOctokit(), src, dest, files),
+  isRepoEmpty: async (repo) => isRepoEmpty(await getOctokit(), repo),
+  initTemplate: async (repo, template) => initTemplateRepo(await getOctokit(), repo, template),
   loadMeta,
   saveMeta,
 };

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -46,6 +46,8 @@ export const seedTemplate: ProjectTemplate = {
     outOfScope: [ { id: uid(), description: "Production support beyond hypercare" } ],
     prereqs: [ { id: uid(), description: "Access to source repo and CI pipeline" } ],
     training: [ { id: uid(), audience: "Ops", topic: "OpenShift Admin", format: "Instructor-led" } ],
+    teamRoles: [ { id: uid(), name: "Architect", responsibilities: "Overall solution design" } ],
+    teamModeling: [ { id: uid(), role: "Architect", weeks: 12 } ],
   },
 };
 
@@ -102,6 +104,8 @@ export function cloneIntoProjectFromTemplate(t: ProjectTemplate, users = seedUse
     outOfScope: defaults.outOfScope ?? [],
     prereqs: defaults.prereqs ?? [],
     training: defaults.training ?? [],
+    teamRoles: defaults.teamRoles ?? [],
+    teamModeling: defaults.teamModeling ?? [],
     sharing: {
       owners: [users[0].id],
       participants: [users[1].id],

--- a/src/lib/github.test.ts
+++ b/src/lib/github.test.ts
@@ -1,4 +1,4 @@
-import { copyTemplateToRepo } from './github';
+import { copyTemplateToRepo, initTemplateRepo } from './github';
 
 const encodedEmpty = Buffer.from('{}').toString('base64');
 
@@ -43,6 +43,34 @@ describe('copyTemplateToRepo', () => {
       message: 'chore: add template.json',
       content: encodedEmpty,
       branch: 'dev',
+    });
+  });
+});
+
+describe('initTemplateRepo', () => {
+  it('creates template.json and README', async () => {
+    const createOrUpdateFileContents = jest.fn().mockResolvedValue({});
+    const repos = { createOrUpdateFileContents };
+    await initTemplateRepo(
+      { repos } as any,
+      { owner: 'o', repo: 'r' },
+      { id: '1', name: 'T', defaults: {} },
+    );
+    expect(createOrUpdateFileContents).toHaveBeenCalledWith({
+      owner: 'o',
+      repo: 'r',
+      path: 'template.json',
+      message: 'chore: add template.json',
+      content: expect.any(String),
+      branch: 'main',
+    });
+    expect(createOrUpdateFileContents).toHaveBeenCalledWith({
+      owner: 'o',
+      repo: 'r',
+      path: 'README.md',
+      message: 'docs: add template README',
+      content: expect.any(String),
+      branch: 'main',
     });
   });
 });

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -65,6 +65,8 @@ export interface Risk { id: string; description: string; mitigation?: string }
 export interface OutOfScope { id: string; description: string }
 export interface Prereq { id: string; description: string }
 export interface TrainingRec { id: string; audience: string; topic: string; format: string }
+export interface TeamRole { id: string; name: string; responsibilities?: string }
+export interface TeamModeling { id: string; role: string; weeks: number }
 
 export type ProjectStatus = "created" | "level of effort completed" | "peer verified" | "delivered to client";
 
@@ -80,6 +82,8 @@ export interface ProjectTemplate {
     outOfScope: OutOfScope[];
     prereqs: Prereq[];
     training: TrainingRec[];
+    teamRoles: TeamRole[];
+    teamModeling: TeamModeling[];
   }>;
 }
 
@@ -96,6 +100,8 @@ export interface Project {
   outOfScope: OutOfScope[];
   prereqs: Prereq[];
   training: TrainingRec[];
+  teamRoles: TeamRole[];
+  teamModeling: TeamModeling[];
   sharing: Sharing;
   createdAt: string;
   updatedAt: string;


### PR DESCRIPTION
## Summary
- detect empty template repositories and initialize with `template.json` + README
- allow creating templates directly from empty repos via UI
- expand template editor to manage outcomes, tasks, risks, scope, prereqs, training, team roles, and team modeling

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689eb7ace744832d9921ad4c37f2d3a5