### PR TITLE
Handle missing template.json and enable template editing

### DIFF
--- a/src/app/Home/Home.test.tsx
+++ b/src/app/Home/Home.test.tsx
@@ -4,5 +4,5 @@ import { Home } from './Home';
 
 it('renders home landing text', () => {
   render(<Home />);
-  expect(screen.getByText(/Project Estimation App/i)).toBeTruthy();
+  expect(screen.getAllByText(/Project Estimation App/i).length).toBeGreaterThan(0);
 });

--- a/src/components/projects/ProjectsList.test.tsx
+++ b/src/components/projects/ProjectsList.test.tsx
@@ -6,6 +6,11 @@ import ProjectsList from './ProjectsList';
 jest.mock('../../lib/api', () => ({
   api: {
     getOpportunity: jest.fn(),
+    saveTemplate: jest.fn(),
+    initTemplate: jest.fn(),
+    copyTemplate: jest.fn(),
+    getTemplate: jest.fn(),
+    isRepoEmpty: jest.fn(),
     loadMeta: jest.fn(() => Promise.resolve({ recents: [], prefs: {} })),
     saveMeta: jest.fn(),
   },

--- a/src/components/templates/TemplatesList.test.tsx
+++ b/src/components/templates/TemplatesList.test.tsx
@@ -8,8 +8,8 @@ import { api } from '../../lib/api';
 jest.mock('../../lib/api', () => ({
   api: {
     getTemplate: jest.fn(),
-    isRepoEmpty: jest.fn(),
     initTemplate: jest.fn(),
+    saveTemplate: jest.fn(),
     loadMeta: jest.fn(() => Promise.resolve({ recents: [], prefs: {} })),
     saveMeta: jest.fn(() => Promise.resolve()),
     copyTemplate: jest.fn(),
@@ -17,7 +17,6 @@ jest.mock('../../lib/api', () => ({
 }));
 
 test('loads template from repo', async () => {
-  (api.isRepoEmpty as jest.Mock).mockResolvedValue(false);
   (api.getTemplate as jest.Mock).mockResolvedValue(seedTemplate);
   render(
     <MemoryRouter>
@@ -30,7 +29,7 @@ test('loads template from repo', async () => {
 });
 
 test('initializes empty template repo', async () => {
-  (api.isRepoEmpty as jest.Mock).mockResolvedValue(true);
+  (api.getTemplate as jest.Mock).mockResolvedValue({});
   (api.initTemplate as jest.Mock).mockResolvedValue(undefined);
   render(
     <MemoryRouter>
@@ -44,5 +43,22 @@ test('initializes empty template repo', async () => {
   fireEvent.change(screen.getByPlaceholderText('Description'), { target: { value: 'desc' } });
   fireEvent.click(screen.getByText('Create template'));
   expect(api.initTemplate).toHaveBeenCalled();
+});
+
+test('edits existing template', async () => {
+  (api.getTemplate as jest.Mock).mockResolvedValue(seedTemplate);
+  render(
+    <MemoryRouter>
+      <TemplatesList />
+    </MemoryRouter>
+  );
+  fireEvent.change(screen.getByPlaceholderText('owner/repo'), { target: { value: 'foo/bar' } });
+  fireEvent.click(screen.getAllByText('Load template')[0]);
+  expect(await screen.findByText(seedTemplate.name)).toBeTruthy();
+  fireEvent.click(screen.getByLabelText('Edit template'));
+  const nameInput = await screen.findByPlaceholderText('Template name');
+  fireEvent.change(nameInput, { target: { value: 'Updated' } });
+  fireEvent.click(screen.getByText('Save template'));
+  expect(api.saveTemplate).toHaveBeenCalled();
 });
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,4 +1,4 @@
-import { loadOpportunity, loadTemplate, copyTemplateToRepo, RepoRef, isRepoEmpty, initTemplateRepo } from './github';
+import { loadOpportunity, loadTemplate, copyTemplateToRepo, RepoRef, isRepoEmpty, initTemplateRepo, saveTemplateRepo } from './github';
 import { loadMeta, saveMeta, UserMeta } from './persistence';
 import { ProjectTemplate, OpportunityInfo } from '../models/types';
 
@@ -8,6 +8,7 @@ export interface API {
   copyTemplate(src: RepoRef, dest: RepoRef, files?: string[]): Promise<void>;
   isRepoEmpty(repo: RepoRef): Promise<boolean>;
   initTemplate(repo: RepoRef, template: ProjectTemplate): Promise<void>;
+  saveTemplate(repo: RepoRef, template: ProjectTemplate): Promise<void>;
   loadMeta(): Promise<UserMeta>;
   saveMeta(update: Partial<UserMeta>): Promise<void>;
 }
@@ -27,6 +28,7 @@ export const api: API = {
   copyTemplate: async (src, dest, files) => copyTemplateToRepo(await getOctokit(), src, dest, files),
   isRepoEmpty: async (repo) => isRepoEmpty(await getOctokit(), repo),
   initTemplate: async (repo, template) => initTemplateRepo(await getOctokit(), repo, template),
+  saveTemplate: async (repo, template) => saveTemplateRepo(await getOctokit(), repo, template),
   loadMeta,
   saveMeta,
 };

--- a/src/lib/github.test.ts
+++ b/src/lib/github.test.ts
@@ -1,5 +1,5 @@
 import { Buffer } from "buffer";
-import { copyTemplateToRepo, initTemplateRepo } from "./github";
+import { copyTemplateToRepo, initTemplateRepo, saveTemplateRepo } from "./github";
 
 const encodedEmpty = Buffer.from("{}").toString("base64");
 
@@ -80,6 +80,26 @@ describe("initTemplateRepo", () => {
       repo: "r",
       path: "README.md",
       message: "docs: add template README",
+      content: expect.any(String),
+      branch: "main",
+    });
+  });
+});
+
+describe("saveTemplateRepo", () => {
+  it("updates template.json", async () => {
+    const createOrUpdateFileContents = jest.fn().mockResolvedValue({});
+    const repos = { createOrUpdateFileContents };
+    await saveTemplateRepo(
+      { repos } as any,
+      { owner: "o", repo: "r" },
+      { id: "1", name: "T", defaults: {} },
+    );
+    expect(createOrUpdateFileContents).toHaveBeenCalledWith({
+      owner: "o",
+      repo: "r",
+      path: "template.json",
+      message: "chore: update template.json",
       content: expect.any(String),
       branch: "main",
     });

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -108,6 +108,25 @@ export async function initTemplateRepo(
   });
 }
 
+export async function saveTemplateRepo(
+  octokit: Octokit,
+  repo: RepoRef,
+  template: ProjectTemplate,
+): Promise<void> {
+  const branch = repo.ref || "main";
+  const content = Buffer.from(JSON.stringify(template, null, 2)).toString(
+    "base64",
+  );
+  await octokit.repos.createOrUpdateFileContents({
+    owner: repo.owner,
+    repo: repo.repo,
+    path: "template.json",
+    message: "chore: update template.json",
+    content,
+    branch,
+  });
+}
+
 export async function copyTemplateToRepo(
   octokit: Octokit,
   source: RepoRef,


### PR DESCRIPTION
## Summary
- prompt to create template when template.json is absent
- allow editing existing template metadata and save to repo
- move template actions to left column with icon buttons and wider layout

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f4e43c2c8832db2351ee06a066219